### PR TITLE
Change build from Makefile to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,44 @@
+cmake_minimum_required(VERSION 2.6)
+project(ssl_refbox)
+
+add_definitions(-std=gnu++0x -Wall -Wextra -Wold-style-cast -Wconversion -Wundef -O2 -g)
+SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
+
+find_package(PkgConfig)
+pkg_check_modules(GTKMM gtkmm-2.4)
+link_directories(${GTKMM_LIBRARY_DIRS})
+include_directories(${GTKMM_INCLUDE_DIRS})
+
+find_package(Protobuf REQUIRED)
+if (EXISTS ${PROTOBUF_PROTOC_EXECUTABLE})
+    message(STATUS "Found PROTOBUF Compiler: ${PROTOBUF_PROTOC_EXECUTABLE}")
+else ()
+    message(FATAL_ERROR "Could not find PROTOBUF Compiler")
+endif ()
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS rcon.proto referee.proto savestate.proto)
+
+include_directories(
+        ${PROJECT_BINARY_DIR}
+        ${PROTOBUF_INCLUDE_DIRS}
+        ${PROJECT_SOURCE_DIR}
+)
+
+set(SOURCE_FILES
+        addrinfolist.cc
+        configuration.cc
+        exception.cc
+        gamecontroller.cc
+        legacypublisher.cc
+        logger.cc
+        main.cc
+        mainwindow.cc
+        protobufpublisher.cc
+        rconsrv.cc
+        savegame.cc
+        socket.cc
+        teams.cc
+        timing.cc
+        udpbroadcast.cc)
+
+add_executable(sslrefbox ${SOURCE_FILES} ${PROTO_SRCS} ${PROTO_HDRS})
+target_link_libraries(sslrefbox ${GTKMM_LIBRARIES} ${PROTOBUF_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.6)
 project(ssl_refbox)
 
-add_definitions(-std=gnu++0x -Wall -Wextra -Wold-style-cast -Wconversion -Wundef -O2 -g)
+add_definitions(-std=gnu++0x -Wall -Wextra -Wundef -O2 -g)
 SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
 
 find_package(PkgConfig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.6)
 project(ssl_refbox)
 
 add_definitions(-std=gnu++0x -Wall -Wextra -Wundef -O2 -g)
+add_definitions(-DPROTOBUF_INLINE_NOT_IN_HEADERS=0)
+
 SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR})
 
 find_package(PkgConfig)

--- a/Makefile
+++ b/Makefile
@@ -1,46 +1,22 @@
-# Standard compiler and linker flags.
-PKG_CONFIG ?= pkg-config
-override CXXFLAGS := -std=gnu++0x -Wall -Wextra -Wold-style-cast -Wconversion -Wundef -O2 -g $(shell $(PKG_CONFIG) --cflags gtkmm-2.4 protobuf | sed 's/-I/-isystem /g') $(CXXFLAGS)
-override LDFLAGS := $(shell $(PKG_CONFIG) --libs-only-L --libs-only-other gtkmm-2.4 protobuf)
-override LDLIBS := $(shell $(PKG_CONFIG) --libs-only-l gtkmm-2.4 protobuf)
+buildDir=build
+#buildDir=build_debug
 
-# The default target.
-.PHONY : world
-world : sslrefbox
+#change to Debug for debug mode
+buildType=Release
+#buildType=Debug
 
-# Gather lists of files of various types.
-protos := $(wildcard *.proto)
-proto_sources := $(patsubst %.proto,%.pb.cc,$(protos))
-proto_headers := $(patsubst %.proto,%.pb.h,$(protos))
-proto_objs := $(patsubst %.proto,%.pb.o,$(protos))
-non_proto_sources := $(filter-out $(proto_sources),$(wildcard *.cc))
-non_proto_headers := $(filter-out $(proto_headers),$(wildcard *.h))
-non_proto_objs := $(patsubst %.cc,%.o,$(non_proto_sources))
-all_sources := $(proto_sources) $(non_proto_sources)
-all_headers := $(proto_headers) $(non_proto_headers)
-all_objs := $(proto_objs) $(non_proto_objs)
+all: build_cmake
 
-# Normal rule to link the final binary.
-sslrefbox : $(all_objs)
-	@echo "LD    $@"
-	@$(CXX) $(LDFLAGS) -o $@ $+ $(LDLIBS)
+$(buildDir)/CMakeLists.txt.copy: CMakeLists.txt
+	mkdir -p $(buildDir) && cd $(buildDir) && cmake -DCMAKE_BUILD_TYPE=$(buildType) .. && \
+		cp ../CMakeLists.txt ./CMakeLists.txt.copy
 
-# Static pattern rule to compile a protobuf source file (with warnings disabled, as they make no sense here).
-$(proto_objs) : %.pb.o : %.pb.cc $(all_headers)
-	@echo "CXX   $@"
-	@$(CXX) $(CPPFLAGS) $(CXXFLAGS) -w -c $<
+build_cmake: $(buildDir)/CMakeLists.txt.copy
+	$(MAKE) -C $(buildDir)
 
-# Static pattern rule to compile a non-protobuf source file.
-$(non_proto_objs) : %.o : %.cc $(all_headers)
-	@echo "CXX   $@"
-	@$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $<
+clean:
+	$(MAKE) -C $(buildDir) clean
 
-# Pattern rule to run protoc on a message definition file.
-%.pb.cc %.pb.h : %.proto
-	@echo "PROTO $(patsubst %.proto,%.pb.cc,$<)"
-	@protoc --cpp_out=. $<
+cleanup_cache:
+	rm -rf $(buildDir) && mkdir $(buildDir)
 
-# Rule to clean intermediates and outputs.
-.PHONY : clean
-clean :
-	$(RM) sslrefbox referee.log referee.sav *.o *.pb.cc *.pb.h

--- a/rcon.proto
+++ b/rcon.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "referee.proto";
 
 // The TCP half-connection from controller to referee box carries a sequence of

--- a/referee.proto
+++ b/referee.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 // Each UDP packet contains one of these messages.
 message SSL_Referee {
 	// The UNIX timestamp when the packet was sent, in microseconds.

--- a/savestate.proto
+++ b/savestate.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 import "referee.proto";
 
 // The type of data saved in the saved state file.


### PR DESCRIPTION
I migrated the Makefile to CMake to be able to build the refbox in my IDE.

The binary is still placed in the root folder.
I copied the Makefile from ssl-vision to have the same convenience. So you can still just run make to build the project.