### PR TITLE
Add optional game events to referee and rcon messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,13 +3,9 @@ client/testclient
 rcon-client/rconclient
 scoreboard/scoreboard
 *.o
-rcon.pb.cc
-rcon.pb.h
+*.pb.cc
+*.pb.h
 referee.log
 referee.sav
-referee.pb.cc
-referee.pb.h
-savestate.pb.cc
-savestate.pb.h
 sslrefbox
 tags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if (EXISTS ${PROTOBUF_PROTOC_EXECUTABLE})
 else ()
     message(FATAL_ERROR "Could not find PROTOBUF Compiler")
 endif ()
-protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS rcon.proto referee.proto savestate.proto)
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS game_event.proto rcon.proto referee.proto savestate.proto)
 
 include_directories(
         ${PROJECT_BINARY_DIR}

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ build_cmake: $(buildDir)/CMakeLists.txt.copy
 
 clean:
 	$(MAKE) -C $(buildDir) clean
+	rm *.o *.pb.h *.pb.cc
 
 cleanup_cache:
 	rm -rf $(buildDir) && mkdir $(buildDir)

--- a/gameEvent.proto
+++ b/gameEvent.proto
@@ -1,0 +1,91 @@
+// a game event that caused a referee command
+message SSL_Referee_Game_Event {
+
+    enum GameEventType {
+        // not set
+        UNKNOWN = 0;
+
+        // an event that is not listed in this enum yet.
+        // Give further details in the message below
+        CUSTOM = 1;
+
+        // Law 3: Number of players
+        NUMBER_OF_PLAYERS = 2;
+
+        // Law 9: Ball out of play
+        BALL_LEFT_FIELD = 3;
+
+        // Law 10: Team scored a goal
+        GOAL = 4;
+
+        // Law 9.3: lack of progress while bringing the ball into play
+        KICK_TIMEOUT = 5;
+
+        // Law ?: There is no progress in game for (10|15)? seconds
+        NO_PROGRESS_IN_GAME = 6;
+
+        // Law 12: Pushing / Substantial Contact
+        BOT_COLLISION = 7;
+
+        // Law 12.2: Defender is completely inside penalty area
+        MULTIPLE_DEFENDER = 8;
+
+        // Law 12: Defender is partially inside penalty area
+        MULTIPLE_DEFENDER_PARTIALLY = 9;
+
+        // Law 12.3: Attacker in defense area
+        ATTACKER_IN_DEFENSE_AREA = 10;
+
+        // Law 12: Icing (kicking over midline and opponent goal line)
+        ICING = 11;
+
+        // Law 12: Ball speed
+        BALL_SPEED = 12;
+
+        // Law 12: Robot speed during STOP
+        ROBOT_STOP_SPEED = 13;
+
+        // Law 12: Maximum dribbling distance
+        BALL_DRIBBLING = 14;
+
+        // Law 12: Touching the opponent goalkeeper
+        ATTACKER_TOUCH_KEEPER = 15;
+
+        // Law 12: Double touch
+        DOUBLE_TOUCH = 16;
+
+        // Law 13-17: Attacker not too close to the opponent's penalty area when ball enters play
+        ATTACKER_TO_DEFENCE_AREA = 17;
+
+        // Law 13-17: Keeping the correct distance to the ball during opponents freekicks
+        DEFENDER_TO_KICK_POINT_DISTANCE = 18;
+
+        // Law 12: A robot holds the ball deliberately
+        BALL_HOLDING = 19;
+
+        // Law 12: The ball entered the goal directly after an indirect kick was performed
+        INDIRECT_GOAL = 20;
+    }
+
+    // the game event type that happened
+    required GameEventType gameEventType = 1;
+
+    // a team
+    enum Team {
+        TEAM_UNKNOWN = 0;
+        TEAM_YELLOW = 1;
+        TEAM_BLUE = 2;
+    }
+
+    // information about an originator
+    message Originator {
+        required Team team = 1;
+        optional uint32 botId = 2;
+    }
+
+    // the team and optionally a designated robot that is the originator of the game event
+    optional Originator originator = 2;
+
+    // a message describing further details of this game event
+    optional string message = 3;
+}

--- a/game_event.proto
+++ b/game_event.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 // a game event that caused a referee command
 message SSL_Referee_Game_Event {
 
@@ -65,6 +67,13 @@ message SSL_Referee_Game_Event {
 
         // Law 12: The ball entered the goal directly after an indirect kick was performed
         INDIRECT_GOAL = 20;
+
+        // Law 9.2: Ball placement
+        BALL_PLACEMENT_FAILED = 21;
+
+        // Law 10: A goal is only scored if the ball has not exceeded a robot height (150mm) between the last
+        // kick of an attacker and the time the ball crossed the goal line.
+        CHIP_ON_GOAL = 22;
     }
 
     // the game event type that happened

--- a/gamecontroller.cc
+++ b/gamecontroller.cc
@@ -291,7 +291,7 @@ bool GameController::command_needs_designated_position(SSL_Referee::Command comm
 	return false;
 }
 
-void GameController::set_command(SSL_Referee::Command command, float designated_x, float designated_y, bool cancelling_timeout_end) {
+void GameController::set_command(SSL_Referee::Command command, float designated_x, float designated_y, bool cancelling_timeout_end, const SSL_Referee_Game_Event *game_event) {
 	SSL_Referee *ref = state.mutable_referee();
 
 	// Record what’s happening.
@@ -392,6 +392,11 @@ void GameController::set_command(SSL_Referee::Command command, float designated_
 	// Record the command timestamp.
 	std::chrono::microseconds diff = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - std::chrono::system_clock::from_time_t(0));
 	ref->set_command_timestamp(static_cast<uint64_t>(diff.count()));
+
+    // copy game event from request
+	if(game_event != NULL) {
+		ref->mutable_gameevent()->CopyFrom(*game_event);
+	}
 
 	// We should save the game state now.
 	save_game(state, configuration.save_filename);

--- a/gamecontroller.h
+++ b/gamecontroller.h
@@ -40,7 +40,7 @@ class GameController : public NonCopyable {
 
 		bool can_set_command(SSL_Referee::Command command) const;
 		static bool command_needs_designated_position(SSL_Referee::Command command);
-		void set_command(SSL_Referee::Command command, float designated_x = 0.0f, float designated_y = 0.0f, bool cancelling_timeout_end = false);
+		void set_command(SSL_Referee::Command command, float designated_x = 0.0f, float designated_y = 0.0f, bool cancelling_timeout_end = false, const SSL_Referee_Game_Event *game_event = NULL);
 
 		void set_teamname(SaveState::Team team, const Glib::ustring &name);
 

--- a/rcon.proto
+++ b/rcon.proto
@@ -1,5 +1,6 @@
 syntax = "proto2";
 import "referee.proto";
+import "gameEvent.proto";
 
 // The TCP half-connection from controller to referee box carries a sequence of
 // these messages, sent on demand, each preceded by its length in bytes as a
@@ -117,6 +118,13 @@ message SSL_RefereeRemoteControlRequest {
 	// appropriate for remote control software managed by a human operator,
 	// where no race condition is possible.
 	optional uint32 last_command_counter = 6;
+
+	// A unique static identifier for each implementation (like each auto-ref implementation, test clients, etc)
+	// Used to identify the source of requests on the receiving side
+	optional string implementation_id = 7;
+
+	// The game event that caused the referee command
+	optional SSL_Referee_Game_Event gameEvent = 8;
 }
 
 // The TCP half-connection from referee box to controller carries a sequence of
@@ -152,6 +160,10 @@ message SSL_RefereeRemoteControlReply {
 		// The request was rejected because a card cannot be issued at this
 		// time.
 		BAD_CARD = 6;
+		// The request was rejected because it found no majority
+		NO_MAJORITY = 7;
+		// The request was rejected because the communication to the ssl-refbox failed
+		COMMUNICATION_FAILED = 8;
 	}
 	required Outcome outcome = 2;
 };

--- a/rcon.proto
+++ b/rcon.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 import "referee.proto";
-import "gameEvent.proto";
+import "game_event.proto";
 
 // The TCP half-connection from controller to referee box carries a sequence of
 // these messages, sent on demand, each preceded by its length in bytes as a

--- a/rconsrv.cc
+++ b/rconsrv.cc
@@ -157,7 +157,8 @@ void RConServer::Connection::execute_request(const SSL_RefereeRemoteControlReque
 		}
 	} else if (request.has_command()) {
 		if (server.controller.can_set_command(request.command())) {
-			server.controller.set_command(request.command(), request.designated_position().x(), request.designated_position().y());
+			const SSL_Referee_Game_Event *game_event = request.has_gameevent() ? &request.gameevent() : NULL;
+			server.controller.set_command(request.command(), request.designated_position().x(), request.designated_position().y(), false, game_event);
 		} else {
 			reply.set_outcome(SSL_RefereeRemoteControlReply::BAD_COMMAND);
 		}

--- a/referee.proto
+++ b/referee.proto
@@ -1,5 +1,7 @@
 syntax = "proto2";
 
+import "gameEvent.proto";
+
 // Each UDP packet contains one of these messages.
 message SSL_Referee {
 	// The UNIX timestamp when the packet was sent, in microseconds.
@@ -156,4 +158,7 @@ message SSL_Referee {
 	// Obviously, the yellow team will play on the opposide half
 	// For compatibility, this field is optional
 	optional bool blueTeamOnPositiveHalf = 10;
+
+	// The game event that caused the referee command
+	optional SSL_Referee_Game_Event gameEvent = 11;
 }

--- a/referee.proto
+++ b/referee.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 
-import "gameEvent.proto";
+import "game_event.proto";
 
 // Each UDP packet contains one of these messages.
 message SSL_Referee {


### PR DESCRIPTION
AutoRefs implement several rules checks and send referee commands accordingly. But on the referee side the cause for the command is unknown. Knowing the event that occurred, we can:
* Visualize this information with a dedicated scoreboard / field screen app
* Compare it in a consensus app
* log it for future analysis

I put the new message type into the existing message formats, as they are optional and thus won't break compatibility.